### PR TITLE
Allow preview when node is directory

### DIFF
--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -356,9 +356,6 @@ end
 
 Preview.show = function(state)
   local node = state.tree:get_node()
-  if node.type == "directory" then
-    return
-  end
 
   if instance then
     instance:findWindow(state)


### PR DESCRIPTION
Currently if you enable preview on a file, it works as expected. As you move up/down, it previews, the files, and on a directory it shows nothing. The directory preview _works_, just shows nothing

However, toggling preview when a directory is selected will simply do nothing, which means even when you then move to a file, preview doesn't work. This is frustrating for event handlers and commands which enable preview (see #783)